### PR TITLE
add me to 'other'

### DIFF
--- a/ORGANISERS.md
+++ b/ORGANISERS.md
@@ -85,3 +85,9 @@ We are here to answer any questions you have, however we are specifically focuse
 ##### Adam Davis
 - Twitter: [@admataz](http://twitter.com/admataz)
 - GitHub: [@admataz](http://github.com/admataz)
+
+## Other
+
+##### Clarkie
+- Twitter: [@clarkieclarkie](http://twitter.com/clarkieclarkie)
+- GitHub: [@clarkie](http://github.com/clarkie)


### PR DESCRIPTION
Should we restructure this so that it's keyed of the organisers rather than the tasks? I didn't know where I fit