### PR TITLE
Updating contact details

### DIFF
--- a/ORGANISERS.md
+++ b/ORGANISERS.md
@@ -1,18 +1,7 @@
 # Contact
 
 ## LNUG Contact Details
-- Email: contact@lnug.org
-- Twitter: @LNUGorg
-
-
-##### Ian Crowther
-- Twitter: [@iancrowther](http://twitter.com/iancrowther)
-- GitHub: [@iancrowther](http://github.com/iancrowther)
-
-##### Oli Evans
-- Twitter: [@olizilla](http://twitter.com/olizilla)
-- GitHub: [@olizilla](http://github.com/olizilla)
-
+- Twitter: [@LNUGorg](http://twitter.com/LNUGorg)
 ## Registration
 
 ##### Jon Kelly
@@ -56,18 +45,6 @@
 - Twitter: [@trevorah](http://twitter.com/trevorah)
 - GitHub: [@trevorah](http://github.com/trevorah)
 
-## Gitter
-
-##### TBA
-
-## Instagram
-
-##### TBA
-
-## Lanyard
-
-##### TBA
-
 ## Attending
 
 ##### Olu Niyi-Awosusi
@@ -85,3 +62,11 @@
 ##### Clarkie
 - Twitter: [@clarkieclarkie](http://twitter.com/clarkieclarkie)
 - GitHub: [@clarkie](http://github.com/clarkie)
+
+##### Ian Crowther
+- Twitter: [@iancrowther](http://twitter.com/iancrowther)
+- GitHub: [@iancrowther](http://github.com/iancrowther)
+
+##### Oli Evans
+- Twitter: [@olizilla](http://twitter.com/olizilla)
+- GitHub: [@olizilla](http://github.com/olizilla)


### PR DESCRIPTION
1 . Removing contact email because I don't think its working. 
2 . Link to @LNUGorg twitter.
3. Removing anything labelled TBA as to my knowledge we are not planning an announcement. 
4 .Moving list of responsibilities to the top.

 @iancrowther and @olizilla - are you happy under `other`? I don't mind making more changes, I'm just trying to keep the main contact details up to date. 

(these changes will show on the lnug.org homepage after this PR is merged and the site built/published)